### PR TITLE
COMP: Move ITK_DISALLOW_COPY_AND_ASSIGN calls to public section.

### DIFF
--- a/include/itkNormalizedCorrelationTwoImageToOneImageMetric.h
+++ b/include/itkNormalizedCorrelationTwoImageToOneImageMetric.h
@@ -45,6 +45,8 @@ class NormalizedCorrelationTwoImageToOneImageMetric :
     public TwoImageToOneImageMetric< TFixedImage, TMovingImage >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(NormalizedCorrelationTwoImageToOneImageMetric);
+
   /** Standard class type alias. */
   using Self = NormalizedCorrelationTwoImageToOneImageMetric;
   using Superclass = TwoImageToOneImageMetric<TFixedImage, TMovingImage >;
@@ -100,9 +102,6 @@ protected:
   void PrintSelf(std::ostream& os, Indent indent) const override;
 
 private:
-  NormalizedCorrelationTwoImageToOneImageMetric(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
   bool    m_SubtractMean;
 };
 

--- a/include/itkSiddonJacobsRayCastInterpolateImageFunction.h
+++ b/include/itkSiddonJacobsRayCastInterpolateImageFunction.h
@@ -58,6 +58,8 @@ class SiddonJacobsRayCastInterpolateImageFunction :
     public InterpolateImageFunction<TInputImage,TCoordRep>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(SiddonJacobsRayCastInterpolateImageFunction);
+
   /** Standard class type alias. */
   using Self = SiddonJacobsRayCastInterpolateImageFunction;
   using Superclass = InterpolateImageFunction<TInputImage,TCoordRep>;
@@ -198,8 +200,6 @@ protected:
   double m_ProjectionAngle; // Linac gantry rotation angle in radians
 
 private:
-  SiddonJacobsRayCastInterpolateImageFunction( const Self& ); //purposely not implemented
-  void operator=( const Self& ); //purposely not implemented
   void ComputeInverseTransform( void ) const;
   TransformPointer m_GantryRotTransform; // Gantry rotation transform
   TransformPointer m_CamShiftTransform; // Camera shift transform camRotTransform

--- a/include/itkTwoImageToOneImageMetric.h
+++ b/include/itkTwoImageToOneImageMetric.h
@@ -53,6 +53,8 @@ template <typename TFixedImage,  typename TMovingImage>
 class TwoImageToOneImageMetric : public SingleValuedCostFunction
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(TwoImageToOneImageMetric);
+
   /** Standard class type alias. */
   using Self = TwoImageToOneImageMetric;
   using Superclass = SingleValuedCostFunction;
@@ -235,9 +237,6 @@ protected:
   mutable MovingImageMaskPointer  m_MovingImageMask;
 
 private:
-  TwoImageToOneImageMetric(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
   FixedImageRegionType        m_FixedImageRegion1;
   FixedImageRegionType        m_FixedImageRegion2;
 };

--- a/include/itkTwoProjectionImageRegistrationMethod.h
+++ b/include/itkTwoProjectionImageRegistrationMethod.h
@@ -65,6 +65,8 @@ template <typename TFixedImage, typename TMovingImage>
 class TwoProjectionImageRegistrationMethod : public ProcessObject
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(TwoProjectionImageRegistrationMethod);
+
   /** Standard class type alias. */
   using Self = TwoProjectionImageRegistrationMethod;
   using Superclass = ProcessObject;
@@ -215,9 +217,6 @@ protected:
 
 
 private:
-  TwoProjectionImageRegistrationMethod(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
   MetricPointer                    m_Metric;
   OptimizerType::Pointer           m_Optimizer;
 


### PR DESCRIPTION
Move `ITK_DISALLOW_COPY_AND_ASSIGN` calls to public section following
the discussion in
https://discourse.itk.org/t/noncopyable

If legacy (pre-macro) copy and assing methods existed, subsitute them
for the `ITK_DISALLOW_COPY_AND_ASSIGN` macro.