### PR TITLE
COMP: Set the minimum required CMake version to 3.10.2.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9.5)
+cmake_minimum_required(VERSION 3.10.2)
 project(TwoProjectionRegistration)
 
 if(NOT ITK_SOURCE_DIR)


### PR DESCRIPTION
As agreed in:
https://discourse.itk.org/t/cmake-update/870/

Set the `cmake_minimum_required` to version **3.10.2**.