### PR TITLE
COMP: Future proof vnl_math_XXX function usage.

### DIFF
--- a/include/itkSiddonJacobsRayCastInterpolateImageFunction.hxx
+++ b/include/itkSiddonJacobsRayCastInterpolateImageFunction.hxx
@@ -38,7 +38,7 @@ CIT 6, 89-94 (1998).
 
 #include "itkSiddonJacobsRayCastInterpolateImageFunction.h"
 
-#include "vnl/vnl_math.h"
+#include "itkMath.h"
 #include <cstdlib>
 
 namespace itk


### PR DESCRIPTION
Prefer C++ over aliased names vnl_math_[min|max] -> std::[min|max]
Prefer vnl_math::abs over deprecated alias vnl_math_abs

In all compilers currently supported by VXL, vnl_math_[min|max]
could be replaced with std::[min|max] without loss of
functionality.  This also circumvents part of the backwards
compatibility requirements as vnl_math_ has been recently
replaced with a namespace of vnl_math::.

Since Wed Nov 14 07:42:48 2012:
The vnl_math_* functions use #define aliases to their
vnl_math::* counterparts in the "real" vnl_math:: namespace.

The new syntax should be backwards compatible to
VXL versions as old as 2012.

Prefer to use itk::Math:: over vnl_math:: namespace