### PR TITLE
BUG: Fix `itk::TwoImageToOneImageMetric` class wrapping.

### DIFF
--- a/wrapping/itkTwoImageToOneImageMetric.wrap
+++ b/wrapping/itkTwoImageToOneImageMetric.wrap
@@ -1,3 +1,3 @@
 itk_wrap_class("itk::TwoImageToOneImageMetric" POINTER)
-  itk_wrap_image_filter("${WRAP_ITK_SCALAR}" 2 2+}
+  itk_wrap_image_filter("${WRAP_ITK_SCALAR}" 2 2+)
 itk_end_wrap_class()


### PR DESCRIPTION
Fix `itk::TwoImageToOneImageMetric` class warpping: change a mistakenly
inserted curly brace for a closing parenthesis.