### PR TITLE
STYLE: Rename ITK_DISALLOW_COPY_AND_ASSIGN to ITK_DISALLOW_COPY_A…

### DIFF
--- a/include/itkNormalizedCorrelationTwoImageToOneImageMetric.h
+++ b/include/itkNormalizedCorrelationTwoImageToOneImageMetric.h
@@ -44,7 +44,7 @@ template <typename TFixedImage, typename TMovingImage>
 class NormalizedCorrelationTwoImageToOneImageMetric : public TwoImageToOneImageMetric<TFixedImage, TMovingImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(NormalizedCorrelationTwoImageToOneImageMetric);
+  ITK_DISALLOW_COPY_AND_MOVE(NormalizedCorrelationTwoImageToOneImageMetric);
 
   /** Standard class type alias. */
   using Self = NormalizedCorrelationTwoImageToOneImageMetric;

--- a/include/itkSiddonJacobsRayCastInterpolateImageFunction.h
+++ b/include/itkSiddonJacobsRayCastInterpolateImageFunction.h
@@ -57,7 +57,7 @@ template <typename TInputImage, typename TCoordRep = float>
 class SiddonJacobsRayCastInterpolateImageFunction : public InterpolateImageFunction<TInputImage, TCoordRep>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(SiddonJacobsRayCastInterpolateImageFunction);
+  ITK_DISALLOW_COPY_AND_MOVE(SiddonJacobsRayCastInterpolateImageFunction);
 
   /** Standard class type alias. */
   using Self = SiddonJacobsRayCastInterpolateImageFunction;

--- a/include/itkTwoImageToOneImageMetric.h
+++ b/include/itkTwoImageToOneImageMetric.h
@@ -52,7 +52,7 @@ template <typename TFixedImage, typename TMovingImage>
 class TwoImageToOneImageMetric : public SingleValuedCostFunction
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(TwoImageToOneImageMetric);
+  ITK_DISALLOW_COPY_AND_MOVE(TwoImageToOneImageMetric);
 
   /** Standard class type alias. */
   using Self = TwoImageToOneImageMetric;

--- a/include/itkTwoProjectionImageRegistrationMethod.h
+++ b/include/itkTwoProjectionImageRegistrationMethod.h
@@ -65,7 +65,7 @@ template <typename TFixedImage, typename TMovingImage>
 class TwoProjectionImageRegistrationMethod : public ProcessObject
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(TwoProjectionImageRegistrationMethod);
+  ITK_DISALLOW_COPY_AND_MOVE(TwoProjectionImageRegistrationMethod);
 
   /** Standard class type alias. */
   using Self = TwoProjectionImageRegistrationMethod;


### PR DESCRIPTION
This PR fixes changes made in [#2053](https://github.com/InsightSoftwareConsortium/ITK/pull/2053/commits/4eac1a0cfb456fad1e3894173a41d7c7de49b08f). Essentially, `ITK_DISALLOW_COPY_AND_ASSIGN` has been changed to `ITK_DISALLOW_COPY_AND_MOVE` to more accurately convey the actions taking place. `ITK_DISALLOW_COPY_AND_ASSIGN` will **only** be used if `ITK_FUTURE_LEGACY_REMOVE=OFF`.

**NOTE:** These changes will cause the GitHub Actions to break, because they currently build `ITK v5.1.0`. The errors persist with `v5.1.1` as well (will update to newest version in separate PR). When tested locally against `master`, I get all tests to pass. The case is the same for the remaining 39 remote modules.