### PR TITLE
COMP: Remove inclusion of .hxx files as headers

### DIFF
--- a/include/itkNormalizedCorrelationTwoImageToOneImageMetric.hxx
+++ b/include/itkNormalizedCorrelationTwoImageToOneImageMetric.hxx
@@ -18,7 +18,6 @@
 #ifndef itkNormalizedCorrelationTwoImageToOneImageMetric_hxx
 #define itkNormalizedCorrelationTwoImageToOneImageMetric_hxx
 
-#include "itkNormalizedCorrelationTwoImageToOneImageMetric.h"
 #include "itkImageRegionConstIteratorWithIndex.h"
 
 namespace itk

--- a/include/itkSiddonJacobsRayCastInterpolateImageFunction.hxx
+++ b/include/itkSiddonJacobsRayCastInterpolateImageFunction.hxx
@@ -36,7 +36,6 @@ CIT 6, 89-94 (1998).
 #ifndef itkSiddonJacobsRayCastInterpolateImageFunction_hxx
 #define itkSiddonJacobsRayCastInterpolateImageFunction_hxx
 
-#include "itkSiddonJacobsRayCastInterpolateImageFunction.h"
 
 #include "itkMath.h"
 #include <cstdlib>

--- a/include/itkSiddonJacobsRayCastInterpolateImageFunction.hxx
+++ b/include/itkSiddonJacobsRayCastInterpolateImageFunction.hxx
@@ -264,7 +264,7 @@ SiddonJacobsRayCastInterpolateImageFunction<TInputImage, TCoordRep>::Evaluate(co
   /* Calculate alpha incremental values when the ray intercepts with x, y, and z-planes */
   if (rayVector[0] != 0)
   {
-    alphaUx = ctPixelSpacing[0] / fabs(rayVector[0]);
+    alphaUx = ctPixelSpacing[0] / itk::Math::abs(rayVector[0]);
   }
   else
   {
@@ -272,7 +272,7 @@ SiddonJacobsRayCastInterpolateImageFunction<TInputImage, TCoordRep>::Evaluate(co
   }
   if (rayVector[1] != 0)
   {
-    alphaUy = ctPixelSpacing[1] / fabs(rayVector[1]);
+    alphaUy = ctPixelSpacing[1] / itk::Math::abs(rayVector[1]);
   }
   else
   {
@@ -280,7 +280,7 @@ SiddonJacobsRayCastInterpolateImageFunction<TInputImage, TCoordRep>::Evaluate(co
   }
   if (rayVector[2] != 0)
   {
-    alphaUz = ctPixelSpacing[2] / fabs(rayVector[2]);
+    alphaUz = ctPixelSpacing[2] / itk::Math::abs(rayVector[2]);
   }
   else
   {

--- a/include/itkTwoImageToOneImageMetric.hxx
+++ b/include/itkTwoImageToOneImageMetric.hxx
@@ -18,7 +18,6 @@
 #ifndef itkTwoImageToOneImageMetric_hxx
 #define itkTwoImageToOneImageMetric_hxx
 
-#include "itkTwoImageToOneImageMetric.h"
 
 
 namespace itk

--- a/include/itkTwoProjectionImageRegistrationMethod.hxx
+++ b/include/itkTwoProjectionImageRegistrationMethod.hxx
@@ -18,7 +18,6 @@
 #ifndef itkTwoProjectionImageRegistrationMethod_hxx
 #define itkTwoProjectionImageRegistrationMethod_hxx
 
-#include "itkTwoProjectionImageRegistrationMethod.h"
 
 
 namespace itk


### PR DESCRIPTION
COMP: Remove inclusion of .hxx files as headers

The ability to include either .h or .hxx files as
header files required recursively reading the
.h files twice.  The added complexity is
unnecessary, costly, and can confuse static
analysis tools that monitor header guardes (due
to reaching the maximum depth of recursion
limits for nested #ifdefs in checking).

